### PR TITLE
Fixed animation stopping when the view is reloaded

### DIFF
--- a/Sources/KeyframeAnimation.swift
+++ b/Sources/KeyframeAnimation.swift
@@ -114,7 +114,7 @@ struct KeyframeAnimationController<T: View>: View {
     private let duration: Double
     private let timingFunctions: [TimingFunction]
     private let keyTimes: [Double]
-    private let keyframeIterator: KeyframeIterator
+    @State private var keyframeIterator: KeyframeIterator
     private var content: Content
     
     var body: some View {


### PR DESCRIPTION
Fix for issue #4. It can be easily replicated if a loader animation is placed in a pushed navigation view.