### PR TITLE
fix: animation smoothness

### DIFF
--- a/Sources/BallBeat.swift
+++ b/Sources/BallBeat.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 public struct BallBeat: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.35, 0, 0.35]
     private let duration = 0.7
     private let timingFunction = TimingFunction.linear
@@ -19,7 +20,7 @@ public struct BallBeat: View {
     public var body: some View {
         GeometryReader(content: self.render)
     }
-
+    
     public init() { }
     
     func render(geometry: GeometryProxy) -> some View {
@@ -32,10 +33,11 @@ public struct BallBeat: View {
                 KeyframeAnimationController(beginTime: self.beginTimes[$0],
                                             duration: self.duration,
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                Circle()
-                                                    .scaleEffect(self.scaleValues[$0])
-                                                    .opacity(self.opacityValues[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    Circle()
+                        .scaleEffect(self.scaleValues[$0])
+                        .opacity(self.opacityValues[$0])
                 }
             }
         }

--- a/Sources/BallClipRotate.swift
+++ b/Sources/BallClipRotate.swift
@@ -45,7 +45,8 @@ public struct BallClipRotate: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
                                             BallClip()
                                                 .scaleEffect(self.scaleValues[$0])
                                                 .rotationEffect(Angle(radians: self.rotationValues[$0]))

--- a/Sources/BallClipRotateMultiple.swift
+++ b/Sources/BallClipRotateMultiple.swift
@@ -59,7 +59,8 @@ public struct BallClipRotateMultiple: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
             VerticalRing()
                 .scaleEffect(scaleValues[$0])
                 .rotationEffect(Angle(radians: rotationValues[$0]))
@@ -77,7 +78,8 @@ public struct BallClipRotateMultiple: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
             HorizontalRing()
                 .scale(0.5)
                 .scaleEffect(scaleValues[$0])

--- a/Sources/BallClipRotatePulse.swift
+++ b/Sources/BallClipRotatePulse.swift
@@ -59,7 +59,8 @@ public struct BallClipRotatePulse: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
             VerticalRing()
                 .scaleEffect(scaleValues[$0])
                 .rotationEffect(Angle(radians: rotationValues[$0]))

--- a/Sources/BallGridBeat.swift
+++ b/Sources/BallGridBeat.swift
@@ -9,23 +9,24 @@
 import SwiftUI
 
 public struct BallGridBeat: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.51, 0.55, 0.83, 0.56, 0.86, 0.0, 0.03, 0.16, 0.47] // Normalized from [0.36, 0.4, 0.68, 0.41, 0.71, -0.15, -0.12, 0.01, 0.32]
     private let durations = [0.96, 0.93, 1.19, 1.13, 1.34, 0.94, 1.2, 0.82, 1.19]
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.25, c0y: 0.1, c1x: 0.25, c1y: 1)
     private let keyTimes = [0, 0.5, 1]
     private let values = [1, 0.7, 1]
-
+    
     public var body: some View {
         GeometryReader(content: self.render)
     }
-
+    
     public init() { }
-
+    
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let spacing = dimension / 32
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-
+        
         return VStack(spacing: spacing) {
             ForEach(0..<3, id: \.self) { row in
                 HStack(spacing: spacing) {
@@ -33,9 +34,10 @@ public struct BallGridBeat: View {
                         KeyframeAnimationController(beginTime: self.beginTimes[3 * row + col],
                                                     duration: self.durations[3 * row + col],
                                                     timingFunctions: timingFunctions,
-                                                    keyTimes: self.keyTimes) {
-                                                        Circle()
-                                                            .opacity(self.values[$0])
+                                                    keyTimes: self.keyTimes,
+                                                    referenceTime: referenceTime) {
+                            Circle()
+                                .opacity(self.values[$0])
                         }
                     }
                 }

--- a/Sources/BallGridPulse.swift
+++ b/Sources/BallGridPulse.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 public struct BallGridPulse: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.11, 0.42, 0.0, 0.65, 0.48, 0.2, 0.63, 0.95, 0.62] // Normalized from [-0.06, 0.25, -0.17, 0.48, 0.31, 0.03, 0.46, 0.78, 0.45]
     private let durations = [0.72, 1.02, 1.28, 1.42, 1.45, 1.18, 0.87, 1.45, 1.06]
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.25, c0y: 0.1, c1x: 0.25, c1y: 1)
@@ -19,7 +20,7 @@ public struct BallGridPulse: View {
     public var body: some View {
         GeometryReader(content: self.render)
     }
-
+    
     public init() { }
     
     func render(geometry: GeometryProxy) -> some View {
@@ -34,10 +35,11 @@ public struct BallGridPulse: View {
                         KeyframeAnimationController(beginTime: self.beginTimes[3 * row + col],
                                                     duration: self.durations[3 * row + col],
                                                     timingFunctions: timingFunctions,
-                                                    keyTimes: self.keyTimes) {
-                                                        Circle()
-                                                            .scaleEffect(self.scaleValues[$0])
-                                                            .opacity(self.opacityValues[$0])
+                                                    keyTimes: self.keyTimes,
+                                                    referenceTime: referenceTime) {
+                            Circle()
+                                .scaleEffect(self.scaleValues[$0])
+                                .opacity(self.opacityValues[$0])
                         }
                     }
                 }

--- a/Sources/BallPulse.swift
+++ b/Sources/BallPulse.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 public struct BallPulse: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.12, 0.24, 0.36]
     private let duration = 0.75
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.2, c0y: 0.68, c1x: 0.18, c1y: 1.08)
@@ -31,8 +32,9 @@ public struct BallPulse: View {
                 KeyframeAnimationController(beginTime: self.beginTimes[$0],
                                             duration: self.duration,
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                Circle().scaleEffect(self.values[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    Circle().scaleEffect(self.values[$0])
                 }
             }
         }

--- a/Sources/BallPulseSync.swift
+++ b/Sources/BallPulseSync.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 public struct BallPulseSync: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.07, 0.14, 0.21]
     private let duration = 0.6
     private let timingFunction = TimingFunction.easeInOut
@@ -35,8 +36,9 @@ public struct BallPulseSync: View {
                 KeyframeAnimationController(beginTime: self.beginTimes[$0],
                                             duration: self.duration,
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                Circle().offset(x: 0, y: values[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    return Circle().offset(x: 0, y: values[$0])
                 }
             }
         }

--- a/Sources/BallRotate.swift
+++ b/Sources/BallRotate.swift
@@ -46,7 +46,8 @@ public struct BallRotate: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
             MyCircles()
                 .scaleEffect(self.scaleValues[$0])
                 .rotationEffect(Angle(radians: self.rotationValues[$0]))

--- a/Sources/BallScale.swift
+++ b/Sources/BallScale.swift
@@ -28,7 +28,8 @@ public struct BallScale: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
                                             Circle()
                                                 .scaleEffect(self.scaleValues[$0])
                                                 .opacity(self.opacityValues[$0])

--- a/Sources/BallScale.swift
+++ b/Sources/BallScale.swift
@@ -14,27 +14,26 @@ public struct BallScale: View {
     private let keyTimes = [0.0, 1.0]
     private let scaleValues: [CGFloat] = [0.0, 1.0]
     private let opacityValues = [1.0, 0.0]
-    
+
     public var body: some View {
         GeometryReader(content: self.render)
     }
 
     public init() { }
-    
+
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-        
+
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
                                            keyTimes: keyTimes,
                                            closedLoop: false) {
-                                            Circle()
-                                                .scaleEffect(self.scaleValues[$0])
-                                                .opacity(self.opacityValues[$0])
-        }
-        .frame(width: dimension, height: dimension, alignment: .center)
+            Circle()
+                .scaleEffect(self.scaleValues[$0])
+                .opacity(self.opacityValues[$0])
+        }.frame(width: dimension, height: dimension, alignment: .center)
     }
 }
 

--- a/Sources/BallScaleRipple.swift
+++ b/Sources/BallScaleRipple.swift
@@ -39,7 +39,8 @@ public struct BallScaleRipple: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: self.duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: self.keyTimes) {
+                                           keyTimes: self.keyTimes,
+                                           closedLoop: false) {
                                             Ring()
                                                 .scaleEffect(self.scaleValues[$0])
                                                 .opacity(self.opacityValues[$0])

--- a/Sources/BallScaleRippleMultiple.swift
+++ b/Sources/BallScaleRippleMultiple.swift
@@ -9,39 +9,41 @@
 import SwiftUI
 
 public struct BallScaleRippleMultiple: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0, 0.2, 0.4]
     private let duration = 1.25
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.21, c0y: 0.53, c1x: 0.56, c1y: 0.8)
     private let keyTimes = [0, 0.7, 1]
     private let scaleValues: [CGFloat] = [0.1, 1, 1]
     private let opacityValues = [1, 0.7, 0]
-    
+
     public var body: some View {
         GeometryReader(content: self.render)
     }
 
     public init() { }
-    
+
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-        
+
         return
-            ZStack {
-                ForEach(0..<3, id: \.self) { index in
-                    KeyframeAnimationController(beginTime: self.beginTimes[index],
-                                                duration: self.duration,
-                                                timingFunctions: timingFunctions,
-                                                keyTimes: self.keyTimes,
-                                                closedLoop: false) {
-                                                    Ring()
-                                                        .scaleEffect(self.scaleValues[$0])
-                                                        .opacity(self.opacityValues[$0])
-                    }
+        ZStack {
+            ForEach(0..<3, id: \.self) { index in
+                KeyframeAnimationController(beginTime: self.beginTimes[index],
+                                            duration: self.duration,
+                                            timingFunctions: timingFunctions,
+                                            keyTimes: self.keyTimes,
+                                            closedLoop: false,
+                                            referenceTime: referenceTime) {
+                    Ring()
+                        .scaleEffect(self.scaleValues[$0])
+                        .opacity(self.opacityValues[$0])
                 }
-                
             }
-            .frame(width: dimension, height: dimension, alignment: .center)
+
+        }
+        .frame(width: dimension, height: dimension, alignment: .center)
     }
 }
 

--- a/Sources/BallScaleRippleMultiple.swift
+++ b/Sources/BallScaleRippleMultiple.swift
@@ -32,7 +32,8 @@ public struct BallScaleRippleMultiple: View {
                     KeyframeAnimationController(beginTime: self.beginTimes[index],
                                                 duration: self.duration,
                                                 timingFunctions: timingFunctions,
-                                                keyTimes: self.keyTimes) {
+                                                keyTimes: self.keyTimes,
+                                                closedLoop: false) {
                                                     Ring()
                                                         .scaleEffect(self.scaleValues[$0])
                                                         .opacity(self.opacityValues[$0])

--- a/Sources/LineScale.swift
+++ b/Sources/LineScale.swift
@@ -9,31 +9,33 @@
 import SwiftUI
 
 public struct LineScale: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.1, 0.2, 0.3, 0.4, 0.5]
     private let duration = 1.0
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.2, c0y: 0.68, c1x: 0.18, c1y: 1.08)
     private let keyTimes = [0, 0.5, 1]
     private let values: [CGFloat] = [1, 0.4, 1]
-    
+
     public var body: some View {
         GeometryReader(content: self.render)
     }
 
     public init() { }
-    
+
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let spacing = dimension / 9
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-        
+
         return HStack(spacing: spacing) {
             ForEach(0..<5, id: \.self) { index in
                 KeyframeAnimationController(beginTime: self.beginTimes[index],
                                             duration: self.duration,
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                RoundedRectangle(cornerRadius: spacing / 2)
-                                                    .scaleEffect(x: 1, y: self.values[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    RoundedRectangle(cornerRadius: spacing / 2)
+                        .scaleEffect(x: 1, y: self.values[$0])
                 }
             }
         }

--- a/Sources/LineScaleParty.swift
+++ b/Sources/LineScaleParty.swift
@@ -9,31 +9,33 @@
 import SwiftUI
 
 public struct LineScaleParty: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.77, 0.29, 0.28, 0.74]
     private let durations = [1.26, 0.43, 1.01, 0.73]
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.25, c0y: 0.1, c1x: 0.25, c1y: 1)
     private let keyTimes = [0, 0.5, 1]
     private let values: [CGFloat] = [1, 0.5, 1]
-
+    
     public var body: some View {
         GeometryReader(content: self.render)
     }
-
+    
     public init() { }
-
+    
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let spacing = dimension / 7
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-
+        
         return HStack(spacing: spacing) {
             ForEach(0..<4, id: \.self) { index in
                 KeyframeAnimationController(beginTime: self.beginTimes[index],
                                             duration: self.durations[index],
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                RoundedRectangle(cornerRadius: spacing / 2)
-                                                    .scaleEffect(self.values[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    RoundedRectangle(cornerRadius: spacing / 2)
+                        .scaleEffect(self.values[$0])
                 }
             }
         }

--- a/Sources/LineScalePulseOut.swift
+++ b/Sources/LineScalePulseOut.swift
@@ -9,31 +9,33 @@
 import SwiftUI
 
 public struct LineScalePulseOut: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.4, 0.2, 0, 0.2, 0.4]
     private let duration = 1.0
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.85, c0y: 0.25, c1x: 0.37, c1y: 0.85)
     private let keyTimes = [0, 0.5, 1]
     private let values: [CGFloat] = [1, 0.4, 1]
-
+    
     public var body: some View {
         GeometryReader(content: self.render)
     }
-
+    
     public init() { }
-
+    
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let spacing = dimension / 9
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-
+        
         return HStack(spacing: spacing) {
             ForEach(0..<5, id: \.self) { index in
                 KeyframeAnimationController(beginTime: self.beginTimes[index],
                                             duration: self.duration,
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                RoundedRectangle(cornerRadius: spacing / 2)
-                                                    .scaleEffect(x: 1, y: self.values[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    RoundedRectangle(cornerRadius: spacing / 2)
+                        .scaleEffect(x: 1, y: self.values[$0])
                 }
             }
         }

--- a/Sources/LineScalePulseOutRapid.swift
+++ b/Sources/LineScalePulseOutRapid.swift
@@ -9,31 +9,33 @@
 import SwiftUI
 
 public struct LineScalePulseOutRapid: View {
+    private let referenceTime = DispatchTime.now()
     private let beginTimes = [0.5, 0.25, 0, 0.25, 0.5]
     private let duration = 0.9
     private let timingFunction = TimingFunction.timingCurve(c0x: 0.11, c0y: 0.49, c1x: 0.38, c1y: 0.78)
     private let keyTimes = [0, 0.8, 0.9]
     private let values: [CGFloat] = [1, 0.3, 1]
-
+    
     public var body: some View {
         GeometryReader(content: self.render)
     }
-
+    
     public init() { }
-
+    
     func render(geometry: GeometryProxy) -> some View {
         let dimension = min(geometry.size.width, geometry.size.height)
         let spacing = dimension / 9
         let timingFunctions = Array(repeating: timingFunction, count: keyTimes.count - 1)
-
+        
         return HStack(spacing: spacing) {
             ForEach(0..<5, id: \.self) { index in
                 KeyframeAnimationController(beginTime: self.beginTimes[index],
                                             duration: self.duration,
                                             timingFunctions: timingFunctions,
-                                            keyTimes: self.keyTimes) {
-                                                RoundedRectangle(cornerRadius: spacing / 2)
-                                                    .scaleEffect(x: 1, y: self.values[$0])
+                                            keyTimes: self.keyTimes,
+                                            referenceTime: referenceTime) {
+                    RoundedRectangle(cornerRadius: spacing / 2)
+                        .scaleEffect(x: 1, y: self.values[$0])
                 }
             }
         }

--- a/Sources/SemiCircleSpin.swift
+++ b/Sources/SemiCircleSpin.swift
@@ -42,7 +42,8 @@ public struct SemiCircleSpin: View {
         return KeyframeAnimationController(beginTime: 0,
                                            duration: duration,
                                            timingFunctions: timingFunctions,
-                                           keyTimes: keyTimes) {
+                                           keyTimes: keyTimes,
+                                           closedLoop: false) {
                                             SemiCircle()
                                                 .rotation(Angle(radians: self.value[$0]))
         }


### PR DESCRIPTION
Change the mechanism to keep track keyframe animations. Instead of using a phantom view's animation, simply use `DispatchQueue`. It also fixes the issue in animations having elements starting at different times when bringing the app from background.

With closed-loop animations—the first and last key frame are the same—start from the second keyframe on repeat for smoother transition
